### PR TITLE
feat: Add mass and hardness properties for Barrel

### DIFF
--- a/assets/blocks/Barrel.block
+++ b/assets/blocks/Barrel.block
@@ -15,5 +15,8 @@
     "inventory" : {
         "stackable" : false,
         "directPickup" : true
-    }
+    },
+    "categories": ["wood"],
+    "hardness": 10,
+    "mass": 20
 }


### PR DESCRIPTION
Increases the "health" of a barrel block from three to ten health points. As well, adds a speed benefit when being broken with an axe.